### PR TITLE
Serialport rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open_dmx"
-description = "A wrapper around the serial library to send DMX data over a serial port"
+description = "A wrapper around the serialport library to send DMX data over a serial port"
 authors = ["David Bühler"]
 license = "MIT"
 repository = "https://github.com/daveiator/open-dmx"
@@ -8,7 +8,7 @@ keywords = ["dmx", "serial","open_dmx","lighting", "enttec"]
 categories = ["api-bindings","multimedia","hardware-support"]
 edition = "2021"
 
-version = "1.0.1"
+version = "1.1.0"
 
 [dependencies]
 serialport = "4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 version = "1.0.1"
 
 [dependencies]
-serial = "0.4.0"
+serialport = "4.3"
 
 thread-priority = { version = "0.13", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [docs-rs-url]: https://docs.rs/open_dmx
 [license-badge]: https://img.shields.io/crates/l/open_dmx.svg?style=for-the-badge
 
-A wrapper around the [**serial**](https://crates.io/crates/serial) library to send [DMX](https://en.wikipedia.org/wiki/DMX512) data over a serial port via the *Open-DMX(RS-485)* protocol
+A wrapper around the [**serialport**](https://crates.io/crates/serialport) library to send [DMX](https://en.wikipedia.org/wiki/DMX512) data over a serial port via the *Open-DMX(RS-485)* protocol
 
 ---
 ## Basic Setup
@@ -23,3 +23,9 @@ fn main() {
 `DMXSerial` updates its channels automatically to the Serial Port for a stable connection. For strobe effects `DMXSerial.update()` can be used, which blocks the main thread until a packet is sent over serial.
 
 The automatic sending can also be disabled with `DMXSerial::open_sync(path)` or `DMXSerial.set_sync()` 
+
+Works with COM-Ports on Windows and TTYPorts on Unix systems.
+
+### Dependencies
+
+For linux `pkg-config` and `libudev` are required.

--- a/src/dmx_serial.rs
+++ b/src/dmx_serial.rs
@@ -23,7 +23,7 @@ const TIME_BREAK_TO_DATA: time::Duration = time::Duration::new(0, 136_000);
 /// 
 /// It uses the RS-485 standard *(aka. Open DMX)* to send **DMX data** over a [SerialPort]. 
 /// 
-/// [SerialPort]: serial::SystemPort
+/// [SerialPort]: serialport::SerialPort
 ///
 #[derive(Debug)]
 pub struct DMXSerial {
@@ -50,7 +50,7 @@ impl DMXSerial {
     /// - **Linux**: `/dev/ttyUSB0`
     /// 
     /// [DMX-Interface]: DMXSerial
-    /// [`path`]: std::ffi::OsStr
+    /// [`path`]: std::str
     /// 
     /// <br>
     /// 
@@ -63,7 +63,7 @@ impl DMXSerial {
     /// 
     /// 
     /// [`set functions`]: DMXSerial::set_channel
-    /// [SerialPort]: serial::SystemPort
+    /// [SerialPort]: serialport::SerialPort
     /// 
     /// # Example
     /// 
@@ -152,6 +152,10 @@ impl DMXSerial {
     /// Reopens the [DMXSerial] on the same [`path`].
     /// 
     /// It keeps the current [`channel`] values.
+    ///
+    /// [`path`]: std::str
+    /// [`channel`]: usize
+    ///
     pub fn reopen(&mut self) -> Result<(), serialport::Error> {
         let channels = self.get_channels();
         let new_dmx = DMXSerial::open(&self.name)?;


### PR DESCRIPTION
Replaces the old serial crate with serialport, for compatibility with custom Baud-rates on linux.

`Closes #6`