### PR TITLE
Added feature to reopen the comport after every write operation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["dmx", "serial","open_dmx","lighting", "enttec"]
 categories = ["api-bindings","multimedia","hardware-support"]
 edition = "2021"
 
-version = "1.1.1"
+version = "1.1.2"
 
 [dependencies]
 serialport = "4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open_dmx"
-description = "A wrapper around the serial library to send DMX data over a serial port"
+description = "A wrapper around the serialport library to send DMX data over a serial port"
 authors = ["David Bühler"]
 license = "MIT"
 repository = "https://github.com/daveiator/open-dmx"
@@ -8,10 +8,10 @@ keywords = ["dmx", "serial","open_dmx","lighting", "enttec"]
 categories = ["api-bindings","multimedia","hardware-support"]
 edition = "2021"
 
-version = "1.0.1"
+version = "1.1.0"
 
 [dependencies]
-serial = "0.4.0"
+serialport = "4.3"
 
 thread-priority = { version = "0.13", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "1.1.0"
 [dependencies]
 serialport = "4.3"
 
-thread-priority = { version = "0.13", optional = true }
+thread-priority = { version = "0.15", optional = true }
 
 [features]
 default = ["thread_priority"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["dmx", "serial","open_dmx","lighting", "enttec"]
 categories = ["api-bindings","multimedia","hardware-support"]
 edition = "2021"
 
-version = "1.1.0"
+version = "1.1.1"
 
 [dependencies]
 serialport = "4.3"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [docs-rs-url]: https://docs.rs/open_dmx
 [license-badge]: https://img.shields.io/crates/l/open_dmx.svg?style=for-the-badge
 
-A wrapper around the [**serial**](https://crates.io/crates/serial) library to send [DMX](https://en.wikipedia.org/wiki/DMX512) data over a serial port via the *Open-DMX(RS-485)* protocol
+A wrapper around the [**serialport**](https://crates.io/crates/serialport) library to send [DMX](https://en.wikipedia.org/wiki/DMX512) data over a serial port via the *Open-DMX(RS-485)* protocol
 
 ---
 ## Basic Setup
@@ -23,3 +23,9 @@ fn main() {
 `DMXSerial` updates its channels automatically to the Serial Port for a stable connection. For strobe effects `DMXSerial.update()` can be used, which blocks the main thread until a packet is sent over serial.
 
 The automatic sending can also be disabled with `DMXSerial::open_sync(path)` or `DMXSerial.set_sync()` 
+
+Works with COM-Ports on Windows and TTYPorts on Unix systems.
+
+### Dependencies
+
+For linux `pkg-config` and `libudev` are required.

--- a/src/dmx_serial.rs
+++ b/src/dmx_serial.rs
@@ -7,32 +7,12 @@ use crate::check_valid_channel;
 use crate::error::{DMXDisconnectionError, DMXChannelValidityError};
 use crate::DMX_CHANNELS;
 
-use serial;
-use serial::SerialPort;
+use serialport::SerialPort;
 
 use std::time;
 use std::io::Write;
-use std::ffi::OsStr;
 use std::thread;
 use std::sync::mpsc;
-
-// Holds the serial port settings for the Break-Signals
-const BREAK_SETTINGS: serial::PortSettings = serial::PortSettings {
-    baud_rate: serial::Baud57600,
-    char_size: serial::Bits7,
-    parity: serial::ParityNone,
-    stop_bits: serial::Stop1,
-    flow_control: serial::FlowNone,
-};
-
-// Holds the serial port settings for the Data-Signals
-const DMX_SETTINGS: serial::PortSettings = serial::PortSettings {
-    baud_rate: serial::BaudOther(250_000),
-    char_size: serial::Bits8,
-    parity: serial::ParityNone,
-    stop_bits: serial::Stop2,
-    flow_control: serial::FlowNone,
-};
 
 // Sleep duration between sending the break and the data
 const TIME_BREAK_TO_DATA: time::Duration = time::Duration::new(0, 136_000);
@@ -43,7 +23,7 @@ const TIME_BREAK_TO_DATA: time::Duration = time::Duration::new(0, 136_000);
 /// 
 /// It uses the RS-485 standard *(aka. Open DMX)* to send **DMX data** over a [SerialPort]. 
 /// 
-/// [SerialPort]: serial::SystemPort
+/// [SerialPort]: serialport::SerialPort
 ///
 #[derive(Debug)]
 pub struct DMXSerial {
@@ -70,7 +50,7 @@ impl DMXSerial {
     /// - **Linux**: `/dev/ttyUSB0`
     /// 
     /// [DMX-Interface]: DMXSerial
-    /// [`path`]: std::ffi::OsStr
+    /// [`path`]: std::str
     /// 
     /// <br>
     /// 
@@ -83,7 +63,7 @@ impl DMXSerial {
     /// 
     /// 
     /// [`set functions`]: DMXSerial::set_channel
-    /// [SerialPort]: serial::SystemPort
+    /// [SerialPort]: serialport::SerialPort
     /// 
     /// # Example
     /// 
@@ -99,20 +79,20 @@ impl DMXSerial {
     /// }
     /// ```
     /// 
-    pub fn open<T: AsRef<OsStr> + ?Sized>(port: &T) -> Result<DMXSerial, serial::Error> {
+    pub fn open(port: &str) -> Result<DMXSerial, serialport::Error> {
 
         let (handler, agent_rx) = mpsc::sync_channel(0);
         let (agent_tx, handler_rec) = mpsc::channel();
 
         // channel default created here!
         let dmx = DMXSerial {
-            name: port.as_ref().to_string_lossy().to_string(),
+            name: port.to_string(),
             channels: ArcRwLock::new([0; DMX_CHANNELS]),
             agent: AgentCommunication::new(agent_tx, agent_rx),
             is_sync: ArcRwLock::new(false),
             min_time_break_to_break: ArcRwLock::new(time::Duration::from_micros(22_700))};
 
-        let mut agent = DMXSerialAgent::open(port, dmx.min_time_break_to_break.read_only())?;
+        let mut agent = DMXSerialAgent::open(&port, dmx.min_time_break_to_break.read_only())?;
         let channel_view = dmx.channels.read_only();
         let is_sync_view = dmx.is_sync.read_only();
         let _ = thread::spawn(move || {
@@ -163,7 +143,7 @@ impl DMXSerial {
     ///         dmx.update();
     ///     }
     /// }
-    pub fn open_sync(port: &str) -> Result<DMXSerial, serial::Error> {
+    pub fn open_sync(port: &str) -> Result<DMXSerial, serialport::Error> {
         let mut dmx = DMXSerial::open(port)?;
         dmx.set_sync();
         Ok(dmx)
@@ -172,7 +152,11 @@ impl DMXSerial {
     /// Reopens the [DMXSerial] on the same [`path`].
     /// 
     /// It keeps the current [`channel`] values.
-    pub fn reopen(&mut self) -> Result<(), serial::Error> {
+    ///
+    /// [`path`]: std::str
+    /// [`channel`]: usize
+    ///
+    pub fn reopen(&mut self) -> Result<(), serialport::Error> {
         let channels = self.get_channels();
         let new_dmx = DMXSerial::open(&self.name)?;
         *self = new_dmx;
@@ -439,36 +423,36 @@ impl<T> AgentCommunication<T> {
 }
 
 struct DMXSerialAgent {
-    port: serial::SystemPort,
+    port: Box<dyn SerialPort>,
     min_b2b: ReadOnly<time::Duration>,
 }
 
 impl DMXSerialAgent {
 
-    pub fn open<T: AsRef<OsStr> + ?Sized>(port: &T, min_b2b: ReadOnly<time::Duration>) -> Result<DMXSerialAgent, serial::Error> {
-        let port = serial::open(port)?;
+    pub fn open (port: &str, min_b2b: ReadOnly<time::Duration>) -> Result<DMXSerialAgent, serialport::Error> {
+        let port = serialport::new(port, 250000)
+        .data_bits(serialport::DataBits::Eight)
+        .stop_bits(serialport::StopBits::Two)
+        .parity(serialport::Parity::None)
+        .flow_control(serialport::FlowControl::None)
+        .open()?;
         let dmx = DMXSerialAgent {
             port,
             min_b2b,
         };
         Ok(dmx)
     }
-    fn send_break(&mut self) -> serial::Result<()> {
-        self.port.configure(&BREAK_SETTINGS)?;
-        self.port.write(&[0x00])?;
-        Ok(())
-    }
 
-    fn send_data(&mut self, data: &[u8]) -> serial::Result<()> {
-        self.port.configure(&DMX_SETTINGS)?;
+    fn send_data(&mut self, data: &[u8]) -> serialport::Result<()> {
         self.port.write(data)?;
         Ok(())
     }
     
-    pub fn send_dmx_packet(&mut self, channels: [u8; DMX_CHANNELS]) -> serial::Result<()> {
+    pub fn send_dmx_packet(&mut self, channels: [u8; DMX_CHANNELS]) -> serialport::Result<()> {
         let start = time::Instant::now();
-        self.send_break()?;
+        self.port.set_break()?;
         thread::sleep(TIME_BREAK_TO_DATA);
+        self.port.clear_break()?;
         let mut prefixed_data = [0; 513];// 1 start byte + 512 channels
         prefixed_data[1..].copy_from_slice(&channels);
         self.send_data(&prefixed_data)?;


### PR DESCRIPTION
This is a workaround for imx_uarts as with these devices the break signal is only working once after opening the com port.
rised version to 1.1.2